### PR TITLE
Return accessToken as part of the login request

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ class TrueVaultClient {
             method: 'POST',
             body: formData
         });
+        tvClient.accessToken = response.user.access_token;
         tvClient.authHeader = TrueVaultClient._makeHeaderForUsername(response.user.access_token);
         return tvClient;
     }


### PR DESCRIPTION
#15 

Developers that need to reuse an` access token` in multiple page loads can now do so from the `login` request. 