### PR TITLE
Resolve schemaId and ownerId bug in createDocument

### DIFF
--- a/index.js
+++ b/index.js
@@ -896,11 +896,11 @@ class TrueVaultClient {
         const body = {document};
 
         if (typeof schemaId === 'string') {
-            body.schemaId = schemaId;
+            body.schema_id = schemaId;
         }
 
         if (typeof ownerId === 'string') {
-            body.ownerId = ownerId;
+            body.owner_id = ownerId;
         }
         const response = await this.performJSONRequest(`v2/vaults/${vaultId}/documents`, {
             method: 'POST',


### PR DESCRIPTION
Found a bug in createDocument that prevented the Schema ID and Owner ID to be accepted by TrueVault API. 